### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function unset(obj, prop) {
       last = segs.pop().slice(0, -1) + '.' + last;
     }
     while (segs.length) obj = obj[prop = segs.shift()];
-    return (delete obj[last]);
+    return (obj != Object.prototype && delete obj[last]);
   }
   return true;
 };

--- a/test.js
+++ b/test.js
@@ -66,6 +66,12 @@ describe('unset', function () {
       unset();
     }).should.throw('expected an object.');
   });
+
+  it('should not pollute object prototype:', function () {
+    Object.prototype.prop = 1;
+    unset({}, '__proto__.prop');
+    Object.prototype.should.hasOwnProperty('prop');
+  });
 });
 
 describe('input path as array paths', function () {
@@ -121,5 +127,11 @@ describe('input path as array paths', function () {
     (function () {
       unset();
     }).should.throw('expected an object.');
+  });
+
+  it('should not pollute object prototype:', function () {
+    Object.prototype.prop = 1;
+    unset({}, ['constructor', 'prototype', 'prop']);
+    Object.prototype.should.hasOwnProperty('prop');
   });
 });


### PR DESCRIPTION
### :bar_chart: Metadata *

`unset-value` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-unset-value

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const unset = require('unset-value')

console.log('Before:', {}.toString)
unset({}, '__proto__.toString')
console.log('After:', {}.toString)
```
2. Execute the following commands in terminal:
```bash
npm i unset-value # Install vulerable package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: [Function: toString]
After: undefined
```

### :fire: Proof of Fix (PoF) *


### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* Added test cases for vulnerability check.
* After fix the functionality is unaffected.
