### PR TITLE
Fix prototype pollution :bug:

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,9 @@ module.exports = function unset(obj, prop) {
 
   if (has(obj, prop)) {
     var segs = isArray ? prop.slice() : prop.split('.');
+    if (segs.indexOf('__proto__') !== -1 || segs.indexOf('constructor') !== -1 || segs.indexOf('prototype') !== -1) {
+      return false;
+    }
     var last = segs.pop();
     while (segs.length && segs[segs.length - 1].slice(-1) === '\\') {
       last = segs.pop().slice(0, -1) + '.' + last;


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: [huntr: Prototype Pollution JavaScript Vulnerability in unset-value](https://huntr.dev/bounties/1-npm-unset-value/)

### ⚙️ Description *

The JavaScript library **unset-value** is vulnerable to Prototype Pollution.
Prototype Pollution refers to the ability to inject properties into existing JavaScript construct prototypes, such as objects.
Which can lead to several types of attacks like Denial of service (DoS), Remote Code Execution, Property Injection, etc.

### 💻 Technical Description *

JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`.
An attacker can manipulate these attributes to overwrite (pollute) a JavaScript application object prototype of the base object by injecting other values.

To fix this we can filter sensitive properties, such as `constructor` or `__proto__` in the `unset()` function in _index.js_.
```node
// index.js, line: 26
var segs = isArray ? prop.slice() : prop.split('.');
if (segs.indexOf('__proto__') !== -1 || segs.indexOf('constructor') !== -1 || segs.indexOf('constructor') !== -1) {
  return false;
}
```

Notice that in _index.js line 20_ (code block 1), we didn't apply the patch. That is because `__proto__`, `prototype` and `constructor` are not members of an object instance (code block 2). And the unset function works only if the `obj` parameter is an object (code block 3).
```node
// code block 1
// index.js, line: 20
if (!isArray && obj.hasOwnProperty(prop)) {
  delete obj[prop];
  return true;
}
```
```node
// code block 2
// foo can be an object instance or a class instance
foo.hasOwnProperty('__proto__')              // false
foo.hasOwnProperty('prototype')              // false
foo.hasOwnProperty('constructor')            // false
```
```node
// code block 3
// index.js, line: 14
if (!isObject(obj)) {
  throw new TypeError('expected an object.');
}
```

### 🐛 Proof of Concept (PoC) *
Before patching the vulnerabilty:
```node
// poc.js
const unset = require('./unset-value')

console.log('Before:', {}.toString)
unset({}, '__proto__.toString')
console.log('After:', {}.toString)
```
![image](https://user-images.githubusercontent.com/59918011/115119710-503e3980-9f99-11eb-86aa-6dd3b84a3871.png)

### 🔥 Proof of Fix (PoF) *

After patching the vulnerabilty:

![image](https://user-images.githubusercontent.com/59918011/115119752-8aa7d680-9f99-11eb-98f6-17944588881c.png)

### 👍 User Acceptance Testing (UAT)

Running these use cases gives the same output before and after the patch:
```node
const unset = require('./unset-value')

var obj = { a: 'b' };
unset(obj, 'a');
console.log(obj);
//=> {}

var one = { a: { b: { c: 'd' } } };
unset(one, 'a.b');
console.log(one);
//=> {a: {}}

var two = { a: { b: { c: 'd' } } };
unset(two, ['a', 'b', 'c']);
console.log(two);
//=> {a: {b: {}}}

var three = { a: { b: { c: 'd', e: 'f' } } };
unset(three, 'a.b.c');
console.log(three);
//=> {a: {b: {e: 'f'}}}
```
![image](https://user-images.githubusercontent.com/59918011/115119861-0ace3c00-9f9a-11eb-9348-0aaea5edde64.png)